### PR TITLE
Call exitWhenFinished on FileCleaningTracker

### DIFF
--- a/ege-framework/src/main/java/pl/psnc/dl/ege/utils/DataBuffer.java
+++ b/ege-framework/src/main/java/pl/psnc/dl/ege/utils/DataBuffer.java
@@ -244,6 +244,7 @@ public class DataBuffer
 			}
 		}
 		items = new HashMap<String,Item>();
+		tracker.exitWhenFinished();
 	}
 	
 	public String getTemporaryDir(){


### PR DESCRIPTION
Without calling this, FileCleaningTracker threads will never terminate. When running
oxgarage as a web service, this is a memory leak.

See https://commons.apache.org/proper/commons-io/javadocs/api-2.2/org/apache/commons/io/FileCleaningTracker.html#exitWhenFinished()

In our running oxgarage instance, we have thousands of these threads hanging around, blocked.
This fixes that issue.