### PR TITLE
add setSystemId for enabling relative XSLT imports

### DIFF
--- a/ege-xsl-converter/src/main/java/pl/psnc/dl/ege/MultiXslConverter.java
+++ b/ege-xsl-converter/src/main/java/pl/psnc/dl/ege/MultiXslConverter.java
@@ -342,7 +342,7 @@ public class MultiXslConverter implements ConfigurableConverter {
 
 	public void configure(Map<String, String> params) throws EGEException {
 		try {
-			xslUri = new File(STYLESHEETS_PATH + File.separator +params.get("xsluri")).toURI();
+			xslUri = new File(STYLESHEETS_PATH +params.get("xsluri")).toURI();
 			String iFormat = params.get("iFormat");
 			StringBuffer sb = new StringBuffer();
 			sb.append("jar:file:");

--- a/ege-xsl-converter/src/main/java/pl/psnc/dl/ege/MultiXslConverter.java
+++ b/ege-xsl-converter/src/main/java/pl/psnc/dl/ege/MultiXslConverter.java
@@ -257,7 +257,9 @@ public class MultiXslConverter implements ConfigurableConverter {
 					throw ex;
 				}
 			}
-			XsltExecutable exec = comp.compile(new StreamSource(is));
+			StreamSource xslSource = new StreamSource(is);
+			xslSource.setSystemId(xslUri.toString());
+			XsltExecutable exec = comp.compile(xslSource);
 			XsltTransformer transformer = exec.load();
 			DocumentBuilder documentBuilder = proc.newDocumentBuilder();
 			documentBuilder.setDTDValidation(false);

--- a/ege-xsl-converter/src/main/resources/META-INF/plugin.xml
+++ b/ege-xsl-converter/src/main/resources/META-INF/plugin.xml
@@ -7,7 +7,7 @@
 	<extension plugin-id="pl.psnc.dl.ege.root" point-id="XslConverter" id="TEItoDocbookConverter">
 		<parameter id="class" value="pl.psnc.dl.ege.MultiXslConverter"/>
 		<parameter id="name" value="TEI to Docbook"/>
-		<parameter id="xsluri" value="docbook/teitodocbook.xsl" />
+		<parameter id="xsluri" value="profiles/default/docbook/to.xsl" />
 		<parameter id="iMimeType" value="text/xml" />
 		<parameter id="iFormat" value="TEI" />
 		<parameter id="oDescription" value="DocBook Document" />
@@ -22,7 +22,7 @@
 	<extension plugin-id="pl.psnc.dl.ege.root" point-id="XslConverter" id="DocbookToTEIConverter">
 		<parameter id="class" value="pl.psnc.dl.ege.MultiXslConverter"/>
 		<parameter id="name" value="Docbook to TEI"/>
-		<parameter id="xsluri" value="docbook/docbooktotei.xsl" />
+		<parameter id="xsluri" value="profiles/default/docbook/from.xsl" />
 		<parameter id="iMimeType" value="text/xml" />
 		<parameter id="iFormat" value="DBK" />
 		<parameter id="iDescription" value="DocBook Document" />


### PR DESCRIPTION
This fixes #9 and #33 where relative imports (to e.g. `../common/verbatim.xsl`) from the main stylesheet were not resolved properly. Adding a SytemID to the Streamsource remedies the issue.
See https://stackoverflow.com/questions/7236291/saxon-error-with-xslt-import-statement