### PR TITLE
update SaxonHE dependency and remove outdated saxon.jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
     - mvn install:install-file -DgroupId=com.sun.star -DartifactId=juh   -Dversion=3.2.1 -Dpackaging=jar -Dfile=jod-lib/juh-3.2.1.jar 
     - mvn install:install-file -DgroupId=com.sun.star -DartifactId=unoil -Dversion=3.2.1 -Dpackaging=jar -Dfile=jod-lib/unoil-3.2.1.jar 
     - mvn install:install-file -DgroupId=com.sun.star -DartifactId=ridl  -Dversion=3.2.1 -Dpackaging=jar -Dfile=jod-lib/ridl-3.2.1.jar 
-    - mvn install:install-file -DgroupId=org.apache.commons.cli -DartifactId=commons-cli -Dversion=1.1 -Dpackaging=jar -Dfile=jod-lib/commons-cli-1.1.jar 
-    - cp saxon9he.jar jsaxon9he.jar
+    - mvn install:install-file -DgroupId=org.apache.commons.cli -DartifactId=commons-cli -Dversion=1.1 -Dpackaging=jar -Dfile=jod-lib/commons-cli-1.1.jar
+    - curl -L https://downloads.sourceforge.net/project/saxon/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip -o saxon.zip && unzip saxon.zip && cp saxon9he.jar jsaxon9he.jar
     - mvn install:install-file -DgroupId=net.sf.saxon -DartifactId=commons-cli -Dversion=9.8 -Dpackaging=jar -Dfile=jsaxon9he.jar
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="Peter Stadler for the TEI Council"
 
 ENV OXGARAGE_BUILD_HOME="/opt/oxgarage-build"
 
-ARG SAXON_URL="https://downloads.sourceforge.net/project/saxon/Saxon-HE/9.8/SaxonHE9-8-0-7J.zip" 
+ARG SAXON_URL="https://downloads.sourceforge.net/project/saxon/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip" 
 
 ADD ${SAXON_URL} /tmp/saxon.zip
 

--- a/ege-xsl-converter/pom.xml
+++ b/ege-xsl-converter/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>9.8.0-7</version>
+      <version>9.8.0-15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/tei-converter/pom.xml
+++ b/tei-converter/pom.xml
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-	<version>9.8.0-7</version>
+	<version>9.8.0-15</version>
     </dependency>
     <dependency>
         <groupId>com.twelvemonkeys.imageio</groupId>

--- a/tei-javalib/pom.xml
+++ b/tei-javalib/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-	<version>9.8.0-7</version>
+	<version>9.8.0-15</version>
     </dependency>
     <dependency>
 	<groupId>com.thaiopensource</groupId>


### PR DESCRIPTION
This PR updates the current SaxonHE9 and removes the outdated and superfluous Saxon jar in the repository.